### PR TITLE
fix+test: add violation for when parser fails to convert node into list; added test for the proc args that can't be converted

### DIFF
--- a/src/tclint/commands/builtin.py
+++ b/src/tclint/commands/builtin.py
@@ -342,27 +342,24 @@ def _proc(args, parser):
     if len(args) != 3:
         raise CommandArgError(f"wrong # of args to proc: got {len(args)}, expected 3")
 
+    # Parse args as list, then iterate over each item to parse arg specifier lists and
+    # do some validation. We don't store non-defaulted arguments as Lists so that they
+    # don't get formatted inside braces.
     arg_list = parser.parse_list(args[1])
-    # Parse arguments with value and default value into list. Raise error if any
-    # argument has more than two values
-    currArg = 0
-    for arg in arg_list.children:
+    for i, arg in enumerate(arg_list.children):
         if isinstance(arg, BareWord):
-            currArg += 1
             continue
 
         arg_specifier = parser.parse_list(arg)
         arg_specifier_len = len(arg_specifier.children)
 
         if arg_specifier_len == 2:
-            arg_list.set(currArg, arg_specifier)
+            arg_list.set(i, arg_specifier)
         elif arg_specifier_len != 1:
             raise CommandArgError(
                 f"too many fields in argument specifier: got {arg_specifier_len},"
                 " expected no more than 2"
             )
-
-        currArg += 1
 
     return args[0:1] + [arg_list, parser.parse_script(args[2])]
 

--- a/src/tclint/commands/builtin.py
+++ b/src/tclint/commands/builtin.py
@@ -354,7 +354,7 @@ def _proc(args, parser):
         arg_specifier_len = len(arg_specifier.children)
 
         if arg_specifier_len == 2:
-            arg_list.set(i, arg_specifier)
+            arg_list.children[i] = arg_specifier
         elif arg_specifier_len != 1:
             raise CommandArgError(
                 f"too many fields in argument specifier: got {arg_specifier_len},"

--- a/src/tclint/commands/builtin.py
+++ b/src/tclint/commands/builtin.py
@@ -36,7 +36,7 @@ from tclint.commands.utils import (
     subcommands,
     eval,
 )
-from tclint.syntax_tree import BareWord, List as ListNode
+from tclint.syntax_tree import BareWord
 
 
 def _check_code(arg):
@@ -342,23 +342,25 @@ def _proc(args, parser):
     if len(args) != 3:
         raise CommandArgError(f"wrong # of args to proc: got {len(args)}, expected 3")
 
-    # Parse args as list, then iterate over each item to parse arg specifier lists and
-    # do some validation. We don't store non-defaulted arguments as Lists so that they
-    # don't get formatted inside braces.
-    arg_list = ListNode(pos=args[1].pos, end_pos=args[1].end_pos)
-    for arg in parser.parse_list(args[1]).children:
-        arg_specifier = parser.parse_list(arg)
+    arg_list = parser.parse_list(args[1])
+    currArg = 0
+    for arg in arg_list.children:
+        if isinstance(arg, BareWord):
+            currArg += 1
+            continue
 
+        arg_specifier = parser.parse_list(arg)
         arg_specifier_len = len(arg_specifier.children)
-        if arg_specifier_len < 2:
-            arg_list.add(arg)
-        elif arg_specifier_len == 2:
-            arg_list.add(arg_specifier)
-        else:
+
+        if arg_specifier_len == 2:
+            arg_list.set(currArg, arg_specifier)
+        elif arg_specifier_len != 1:
             raise CommandArgError(
                 f"too many fields in argument specifier: got {arg_specifier_len},"
                 " expected no more than 2"
             )
+
+        currArg += 1
 
     return args[0:1] + [arg_list, parser.parse_script(args[2])]
 

--- a/src/tclint/commands/builtin.py
+++ b/src/tclint/commands/builtin.py
@@ -343,6 +343,8 @@ def _proc(args, parser):
         raise CommandArgError(f"wrong # of args to proc: got {len(args)}, expected 3")
 
     arg_list = parser.parse_list(args[1])
+    # Parse arguments with value and default value into list. Raise error if any
+    # argument has more than two values
     currArg = 0
     for arg in arg_list.children:
         if isinstance(arg, BareWord):

--- a/src/tclint/config.py
+++ b/src/tclint/config.py
@@ -152,13 +152,17 @@ def _validate_config(config):
         },
     }
 
-    schema = Schema({
-        # exclude and extensions can only be used in global context
-        Optional("exclude"): _VALIDATORS["exclude"],
-        Optional("extensions"): _VALIDATORS["extensions"],
-        **base_config,
-        Optional("fileset"): Schema([{"paths": [Use(pathlib.Path)], **base_config}]),
-    })
+    schema = Schema(
+        {
+            # exclude and extensions can only be used in global context
+            Optional("exclude"): _VALIDATORS["exclude"],
+            Optional("extensions"): _VALIDATORS["extensions"],
+            **base_config,
+            Optional("fileset"): Schema(
+                [{"paths": [Use(pathlib.Path)], **base_config}]
+            ),
+        }
+    )
 
     try:
         return schema.validate(config)

--- a/src/tclint/parser.py
+++ b/src/tclint/parser.py
@@ -520,9 +520,7 @@ class Parser:
             return node
 
         if node.contents is None:
-            raise CommandArgError(
-                "Can't find content of argument to parse it as a list"
-            )
+            raise CommandArgError("Failed to convert node into list")
 
         ts = Lexer(pos=node.contents_pos)
         ts.input(node.contents)

--- a/src/tclint/parser.py
+++ b/src/tclint/parser.py
@@ -516,8 +516,13 @@ class Parser:
         that doesn't get used when generating the main syntax tree, but is used
         in command-specific argument parsing.
         """
+        if isinstance(node, List):
+            return node
+
         if node.contents is None:
-            return None
+            raise CommandArgError(
+                "Can't find content of argument to parse it as a list"
+            )
 
         ts = Lexer(pos=node.contents_pos)
         ts.input(node.contents)

--- a/src/tclint/parser.py
+++ b/src/tclint/parser.py
@@ -520,7 +520,10 @@ class Parser:
             return node
 
         if node.contents is None:
-            raise CommandArgError("Failed to convert node into list")
+            raise CommandArgError(
+                "expected braced word or word without substitutions in argument"
+                " interpreted as list"
+            )
 
         ts = Lexer(pos=node.contents_pos)
         ts.input(node.contents)

--- a/src/tclint/syntax_tree.py
+++ b/src/tclint/syntax_tree.py
@@ -1,4 +1,4 @@
-"""Classes for representing and interacting with Tcl syntax trees. """
+"""Classes for representing and interacting with Tcl syntax trees."""
 
 
 class Visitor:
@@ -88,6 +88,9 @@ class Node:
 
     def add(self, node):
         self.children.append(node)
+
+    def set(self, pos, node):
+        self.children[pos] = node
 
     @property
     def contents(self):
@@ -188,12 +191,12 @@ class Node:
             return lines
 
         if len(self.children) != len(other.children):
-            my_children = ",".join([
-                child.__class__.__name__ for child in self.children
-            ])
-            other_children = ",".join([
-                child.__class__.__name__ for child in other.children
-            ])
+            my_children = ",".join(
+                [child.__class__.__name__ for child in self.children]
+            )
+            other_children = ",".join(
+                [child.__class__.__name__ for child in other.children]
+            )
 
             lines += [f"{indent}-{my_cls}({my_children})"]
             lines += [f"{indent}+{other_cls}({other_children})"]

--- a/src/tclint/syntax_tree.py
+++ b/src/tclint/syntax_tree.py
@@ -89,9 +89,6 @@ class Node:
     def add(self, node):
         self.children.append(node)
 
-    def set(self, pos, node):
-        self.children[pos] = node
-
     @property
     def contents(self):
         """This is overloaded by word Nodes that may have concrete contents.

--- a/tests/openroad/test_help_parser.py
+++ b/tests/openroad/test_help_parser.py
@@ -31,10 +31,12 @@ def test_exclusive():
     expected = Command(
         "estimate_parasitics",
         [
-            ExclusiveArgs([
-                Switch("-placement"),
-                Switch("-global_routing"),
-            ])
+            ExclusiveArgs(
+                [
+                    Switch("-placement"),
+                    Switch("-global_routing"),
+                ]
+            )
         ],
     )
     assert tree == expected, f"{tree} != {expected}"
@@ -46,11 +48,13 @@ def test_exclusive_mixed_keys():
         "command",
         [
             OptionalArg(
-                ExclusiveArgs([
-                    Switch("-foo", AnyVal("foo")),
-                    Switch("-bar"),
-                    Switch("-baz", AnyVal("baz")),
-                ])
+                ExclusiveArgs(
+                    [
+                        Switch("-foo", AnyVal("foo")),
+                        Switch("-bar"),
+                        Switch("-baz", AnyVal("baz")),
+                    ]
+                )
             )
         ],
     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,6 +2,7 @@ import pathlib
 
 import pytest
 
+from tclint.commands import CommandArgError
 from tclint.parser import (
     Parser,
     Script,
@@ -573,7 +574,7 @@ def test_parse_list_into_list():
 
 
 def assert_parse_list_failed_to_convert_into_list(node):
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(CommandArgError) as exc_info:
         parse_list(node)
     assert (
         str(exc_info.value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -575,7 +575,11 @@ def test_parse_list_into_list():
 def assert_parse_list_failed_to_convert_into_list(node):
     with pytest.raises(Exception) as exc_info:
         parse_list(node)
-    assert str(exc_info.value) == "Failed to convert node into list"
+    assert (
+        str(exc_info.value)
+        == "expected braced word or word without substitutions in argument"
+        " interpreted as list"
+    )
 
 
 def test_parse_list_failed_to_convert_into_list():
@@ -819,7 +823,11 @@ def assert_proc_args_cant_be_converted_into_list(script, start, end):
     parser.parse(script)
     assert len(parser.violations) == 1
     assert parser.violations[0].id == Rule("command-args")
-    assert parser.violations[0].message == "Failed to convert node into list"
+    assert (
+        parser.violations[0].message
+        == "expected braced word or word without substitutions in argument"
+        " interpreted as list"
+    )
     assert parser.violations[0].start == start
     assert parser.violations[0].end == end
 

--- a/tests/test_tclsp.py
+++ b/tests/test_tclsp.py
@@ -113,8 +113,10 @@ async def test_format(client: pytest_lsp.LanguageClient, tmp_path):
     # Check that tclint config overrides client config
     config = tmp_path / "tclint.toml"
     with open(config, "w") as f:
-        f.write("""[style]
-indent = tab""")
+        f.write(
+            """[style]
+indent = tab"""
+        )
 
     client.workspace_did_change_watched_files(
         # `changes` isn't used by our server impl, so we can cheat and keep this empty


### PR DESCRIPTION
Fixes https://github.com/nmoroze/tclint/issues/77.

This includes basic test for checking if the error is properly raised, and the violation is properly added by the parser.

**NOTE:** I took the opportunity to implement the `set` method to the `Node` class for testing the concept of modifying the children nodes in future passes over the AST. Then, I refactored the steps for the `proc` command to use it and to remove duplicated `parse_list` step.