### PR TITLE
fix+test: arg expansion is a regular braced word if followed by word boundaries like semicolon or right bracket + added tests

### DIFF
--- a/src/tclint/parser.py
+++ b/src/tclint/parser.py
@@ -301,8 +301,14 @@ class Parser:
 
         ts.assert_(TOK_ARG_EXPANSION)
 
-        # Arg expansion is just a regular braced word if followed by whitespace
-        if ts.type() in {TOK_WS, TOK_BACKSLASH_NEWLINE, TOK_NEWLINE, TOK_EOF}:
+        delimiters = [TOK_WS, TOK_BACKSLASH_NEWLINE, TOK_NEWLINE, TOK_SEMI, TOK_EOF]
+        if in_command_sub:
+            delimiters.append(TOK_RBRACKET)
+
+        # Arg expansion is just a regular braced word if followed by whitespace,
+        # or other word boundaries such as semicolon or right bracket
+        # (in command substitution)
+        if ts.type() in delimiters:
             return BracedWord("*", pos=pos, end_pos=ts.pos())
 
         return ArgExpansion(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -111,6 +111,24 @@ def test_arg_expansion():
     )
 
 
+def test_no_arg_expansion_before_semicolon():
+    script = "puts {*};"
+    tree = parse(script)
+    assert tree == Script(Command(BareWord("puts"), BracedWord("*")))
+
+
+def test_no_arg_expansion_in_command_sub():
+    script = "set any [list {*}]"
+    tree = parse(script)
+    assert tree == Script(
+        Command(
+            BareWord("set"),
+            BareWord("any"),
+            CommandSub(Command(BareWord("list"), BracedWord("*"))),
+        )
+    )
+
+
 def test_weird_code_block():
     """Test that } that appears to be in comment actually terminates body of
     proc."""


### PR DESCRIPTION
Fixes #84 