### PR TITLE
LSP goto definition / goto reference

### DIFF
--- a/src/tclint/symbol_table.py
+++ b/src/tclint/symbol_table.py
@@ -15,14 +15,17 @@ class SymbolTable:
         self.sym_ref = {k: defaultdict(list) for k in self.KEYS}
 
     def add_proc_reference(self, name: str, command: Command) -> None:
+        """Add reference to procedure"""
         logging.debug(f"Reference to proc {name} at {command._pos_str()}")
         self.sym_ref["proc"][name].append((command.pos, command.end_pos))
 
     def add_var_reference(self, name: str, var_sub: VarSub) -> None:
+        """Add reference to variable"""
         logging.debug(f"Reference to var {name} at {var_sub._pos_str()}")
         self.sym_ref["var"][name].append((var_sub.pos, var_sub.end_pos))
 
     def add_definition(self, sym_type: str, command: Command) -> None:
+        """Add definition of either procedure or variable (according to sym_type)"""
         if len(command.args) == 0:
             return
 
@@ -31,7 +34,8 @@ class SymbolTable:
         logging.debug(f"Definition of {sym_type} {name} at {def_node._pos_str()}")
         self.sym_def[sym_type][name].append((def_node.pos, def_node.end_pos))
 
-    def lookup(self, node: Node, table: dict):
+    def lookup(self, node: Node, table: dict) -> List[tuple[tuple, tuple]]:
+        """Lookup either reference(s) or definition(s) of the thing (procedure or variable) pointed at by node"""
         ts = self.type_and_symbol(node)
         if ts is None:
             return []
@@ -44,9 +48,11 @@ class SymbolTable:
         return table[key][word]
 
     def lookup_definition(self, node: Node) -> List[tuple[tuple, tuple]]:
+        """Lookup definition(s) of the thing (procedure or variable) pointed at by node"""
         return self.lookup(node, self.sym_def)
 
     def lookup_references(self, node: Node) -> List[tuple[tuple, tuple]]:
+        """Lookup reference(s) to the thing (procedure or variable) pointed at by node"""
         return self.lookup(node, self.sym_ref)
 
     def type_and_symbol(self, node: Node) -> tuple[str, str] | None:
@@ -112,7 +118,7 @@ class SymbolTableBuilder(Visitor):
             self.table.add_definition("var", command)
         elif key == "proc":
             self.table.add_definition("proc", command)
-        else:
+        elif key is not None:
             self.table.add_proc_reference(key, command)
 
     def visit_var_sub(self, var_sub: VarSub):

--- a/src/tclint/symbol_table.py
+++ b/src/tclint/symbol_table.py
@@ -1,0 +1,53 @@
+import logging
+from collections import defaultdict
+
+from tclint.syntax_tree import (
+    Visitor,
+    Command,
+)
+
+
+class SymbolTable:
+    """Holds a symbol table (definition & references of symbols)."""
+
+    KEYS = ("proc", "set")
+
+    def __init__(self):
+        self.sym_def = {k: defaultdict(list) for k in self.KEYS}
+        self.sym_ref = {k: defaultdict(list) for k in self.KEYS}
+
+    def add_command(self, key: str, command: Command) -> None:
+        if key not in self.KEYS:
+            return
+
+        if len(command.args) == 0:
+            # This is a syntax error, just ignore it
+            return
+
+        name = command.args[0].contents
+
+        logging.debug(f"Definition of {key}: {name} at: {command._pos_str()}")
+        self.sym_def[key][name].append((command.pos, command.end_pos))
+
+    def lookup_definition(self, word: str) -> tuple[tuple, tuple] | None:
+        logging.debug(f"Lookup definition of {word}")
+        if word not in self.sym_def["proc"]:
+            return None
+        defs = self.sym_def["proc"][word]
+        if len(defs) > 1:
+            logging.warning(f"Multiple definitions ({len(defs)}) of '{word}'")
+        return defs[0]
+
+
+class SymbolTableBuilder(Visitor):
+    """Builds a symbol table."""
+
+    def __init__(self):
+        self.table = SymbolTable()
+
+    def build(self, tree):
+        tree.accept(self, recurse=True)
+
+    def visit_command(self, command: Command):
+        key = command.routine.contents
+        self.table.add_command(key, command)

--- a/src/tclint/symbol_table.py
+++ b/src/tclint/symbol_table.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from typing import List
 
 from tclint.syntax_tree import (
+    VarSub,
     Visitor,
     Command,
 )
@@ -17,17 +18,17 @@ class SymbolTable:
         self.sym_def = {k: defaultdict(list) for k in self.KEYS}
         self.sym_ref = {k: defaultdict(list) for k in self.KEYS}
 
-    def add_reference(self, key: str, command: Command) -> None:
-        if key.startswith("$"):
-            # TODO: add reference to variable
-            return
-
-        logging.debug(f"Reference to {key} at: {command._pos_str()}")
+    def add_proc_reference(self, key: str, command: Command) -> None:
+        logging.debug(f"Reference to proc {key} at: {command._pos_str()}")
         self.sym_ref["proc"][key].append((command.pos, command.end_pos))
+
+    def add_var_reference(self, key: str, var_sub: VarSub) -> None:
+        logging.debug(f"Reference to var {key} at: {var_sub._pos_str()}")
+        self.sym_ref["set"][key].append((var_sub.pos, var_sub.end_pos))
 
     def add_command(self, key: str, command: Command) -> None:
         if key not in self.KEYS:
-            return self.add_reference(key, command)
+            return self.add_proc_reference(key, command)
 
         if len(command.args) == 0:
             # This is a syntax error, just ignore it
@@ -40,9 +41,15 @@ class SymbolTable:
 
     def lookup_definition(self, word: str) -> tuple[tuple, tuple] | None:
         logging.debug(f"Lookup definition of {word}")
-        if word not in self.sym_def["proc"]:
+        if word.startswith("$"):
+            key = "set"
+            word = word[1:]
+        else:
+            key = "proc"
+
+        if word not in self.sym_def[key]:
             return None
-        defs = self.sym_def["proc"][word]
+        defs = self.sym_def[key][word]
         if len(defs) > 1:
             logging.warning(f"Multiple definitions ({len(defs)}) of '{word}'")
         return defs[0]
@@ -66,3 +73,10 @@ class SymbolTableBuilder(Visitor):
     def visit_command(self, command: Command):
         key = command.routine.contents
         self.table.add_command(key, command)
+
+    def visit_var_sub(self, var_sub: VarSub):
+        key = var_sub.value
+        if key is None:
+            logging.warning(f"VarSub without value at {var_sub._pos_str()}")
+            return
+        self.table.add_var_reference(key, var_sub)

--- a/src/tclint/symbol_table.py
+++ b/src/tclint/symbol_table.py
@@ -15,20 +15,21 @@ class SymbolTable:
         self.sym_ref = {k: defaultdict(list) for k in self.KEYS}
 
     def add_proc_reference(self, name: str, command: Command) -> None:
-        logging.debug(f"Reference to proc {name} at: {command._pos_str()}")
+        logging.debug(f"Reference to proc {name} at {command._pos_str()}")
         self.sym_ref["proc"][name].append((command.pos, command.end_pos))
 
     def add_var_reference(self, name: str, var_sub: VarSub) -> None:
-        logging.debug(f"Reference to var {name} at: {var_sub._pos_str()}")
+        logging.debug(f"Reference to var {name} at {var_sub._pos_str()}")
         self.sym_ref["var"][name].append((var_sub.pos, var_sub.end_pos))
 
     def add_definition(self, sym_type: str, command: Command) -> None:
         if len(command.args) == 0:
             return
-        name = command.args[0].contents
 
-        logging.debug(f"Definition of {sym_type}: {name} at: {command._pos_str()}")
-        self.sym_def[sym_type][name].append((command.pos, command.end_pos))
+        def_node = command.args[0]
+        name = def_node.contents
+        logging.debug(f"Definition of {sym_type} {name} at {def_node._pos_str()}")
+        self.sym_def[sym_type][name].append((def_node.pos, def_node.end_pos))
 
     def lookup(self, node: Node, table: dict):
         ts = self.type_and_symbol(node)

--- a/src/tclint/symbol_table.py
+++ b/src/tclint/symbol_table.py
@@ -2,63 +2,96 @@ import logging
 from collections import defaultdict
 from typing import List
 
-from tclint.syntax_tree import (
-    VarSub,
-    Visitor,
-    Command,
-)
+from tclint.syntax_tree import BareWord, VarSub, Visitor, Command, Node
 
 
 class SymbolTable:
     """Holds a symbol table (definition & references of symbols)."""
 
-    KEYS = ("proc", "set")
+    KEYS = ("proc", "var")
 
     def __init__(self):
         self.sym_def = {k: defaultdict(list) for k in self.KEYS}
         self.sym_ref = {k: defaultdict(list) for k in self.KEYS}
 
-    def add_proc_reference(self, key: str, command: Command) -> None:
-        logging.debug(f"Reference to proc {key} at: {command._pos_str()}")
-        self.sym_ref["proc"][key].append((command.pos, command.end_pos))
+    def add_proc_reference(self, name: str, command: Command) -> None:
+        logging.debug(f"Reference to proc {name} at: {command._pos_str()}")
+        self.sym_ref["proc"][name].append((command.pos, command.end_pos))
 
-    def add_var_reference(self, key: str, var_sub: VarSub) -> None:
-        logging.debug(f"Reference to var {key} at: {var_sub._pos_str()}")
-        self.sym_ref["set"][key].append((var_sub.pos, var_sub.end_pos))
+    def add_var_reference(self, name: str, var_sub: VarSub) -> None:
+        logging.debug(f"Reference to var {name} at: {var_sub._pos_str()}")
+        self.sym_ref["var"][name].append((var_sub.pos, var_sub.end_pos))
 
-    def add_command(self, key: str, command: Command) -> None:
-        if key not in self.KEYS:
-            return self.add_proc_reference(key, command)
-
+    def add_definition(self, sym_type: str, command: Command) -> None:
         if len(command.args) == 0:
-            # This is a syntax error, just ignore it
             return
-
         name = command.args[0].contents
 
-        logging.debug(f"Definition of {key}: {name} at: {command._pos_str()}")
-        self.sym_def[key][name].append((command.pos, command.end_pos))
+        logging.debug(f"Definition of {sym_type}: {name} at: {command._pos_str()}")
+        self.sym_def[sym_type][name].append((command.pos, command.end_pos))
 
-    def lookup_definition(self, word: str) -> tuple[tuple, tuple] | None:
-        logging.debug(f"Lookup definition of {word}")
-        if word.startswith("$"):
-            key = "set"
-            word = word[1:]
-        else:
-            key = "proc"
+    def lookup(self, node: Node, table: dict):
+        ts = self.type_and_symbol(node)
+        if ts is None:
+            return []
+        key, word = ts
 
-        if word not in self.sym_def[key]:
-            return None
-        defs = self.sym_def[key][word]
-        if len(defs) > 1:
-            logging.warning(f"Multiple definitions ({len(defs)}) of '{word}'")
-        return defs[0]
+        logging.debug(f"Lookup {key} definition of '{word}'")
 
-    def lookup_references(self, word: str) -> List[tuple[tuple, tuple]] | None:
-        logging.debug(f"Lookup references of {word}")
-        if word not in self.sym_ref["proc"]:
-            return None
-        return self.sym_ref["proc"][word]
+        if word not in table[key]:
+            return []
+        return table[key][word]
+
+    def lookup_definition(self, node: Node) -> List[tuple[tuple, tuple]]:
+        return self.lookup(node, self.sym_def)
+
+    def lookup_references(self, node: Node) -> List[tuple[tuple, tuple]]:
+        return self.lookup(node, self.sym_ref)
+
+    def type_and_symbol(self, node: Node) -> tuple[str, str] | None:
+        """Get symbol type and symbol text to look for from the node under the cursor."""
+        # "proc foo" with cursor over "proc"
+        if (
+            isinstance(node, BareWord)
+            and node.value == "proc"
+            and isinstance(node.next, BareWord)
+        ):
+            return "proc", node.next.value
+        # "proc foo" with cursor over "foo"
+        if (
+            isinstance(node, BareWord)
+            and isinstance(node.prev, BareWord)
+            and node.prev.value == "proc"
+            and node.value is not None
+        ):
+            return "proc", node.value
+        # "foo" as first word in a statement
+        if (
+            isinstance(node, BareWord)
+            and node.prev is None
+            and node.value is not None
+            and node.value != "set"
+        ):
+            return "proc", node.value
+
+        # "set foo" with cursor over "set"
+        if (
+            isinstance(node, BareWord)
+            and node.value == "set"
+            and isinstance(node.next, BareWord)
+        ):
+            return "var", node.next.value
+        # "set foo" with cursor over "foo"
+        if (
+            isinstance(node, BareWord)
+            and isinstance(node.prev, BareWord)
+            and node.prev.value == "set"
+            and node.value is not None
+        ):
+            return "var", node.value
+        # "$foo"
+        if isinstance(node, VarSub) and node.value is not None:
+            return "var", node.value
 
 
 class SymbolTableBuilder(Visitor):
@@ -67,12 +100,19 @@ class SymbolTableBuilder(Visitor):
     def __init__(self):
         self.table = SymbolTable()
 
-    def build(self, tree):
+    def build(self, tree) -> SymbolTable:
+        """Run the builder visitor through the syntax tree, building a table."""
         tree.accept(self, recurse=True)
+        return self.table
 
     def visit_command(self, command: Command):
         key = command.routine.contents
-        self.table.add_command(key, command)
+        if key == "set":
+            self.table.add_definition("var", command)
+        elif key == "proc":
+            self.table.add_definition("proc", command)
+        else:
+            self.table.add_proc_reference(key, command)
 
     def visit_var_sub(self, var_sub: VarSub):
         key = var_sub.value

--- a/src/tclint/syntax_tree.py
+++ b/src/tclint/syntax_tree.py
@@ -1,4 +1,6 @@
-"""Classes for representing and interacting with Tcl syntax trees. """
+"""Classes for representing and interacting with Tcl syntax trees."""
+
+from typing import Self
 
 
 class Visitor:

--- a/src/tclint/syntax_tree.py
+++ b/src/tclint/syntax_tree.py
@@ -84,10 +84,19 @@ class Node:
         if not all(isinstance(v, Node) for v in init):
             raise TypeError("Children must be Node instances")
 
+        self.prev = None
+        self.next = None
         self.children = list(init)
+        self.update_children_links()
 
     def add(self, node):
         self.children.append(node)
+        self.update_children_links()
+
+    def update_children_links(self):
+        for i in range(1, len(self.children)):
+            self.children[i].prev = self.children[i - 1]
+            self.children[i - 1].next = self.children[i]
 
     @property
     def contents(self):

--- a/src/tclint/syntax_tree.py
+++ b/src/tclint/syntax_tree.py
@@ -222,6 +222,30 @@ class Node:
         for child in self.children:
             child.accept(visitor, recurse=True)
 
+    def _pos_match(self, line: int, col: int) -> bool:
+        """Return True if pos is within this node's block"""
+        if self.pos is None:
+            return False
+        if self.end_pos is None:
+            return line == self.pos[0] and col == self.pos[1]
+        # FIXME: check for off-by-one with end_pos
+        return (
+            line >= self.pos[0]
+            and line <= self.end_pos[0]
+            and (col >= self.pos[1] or line > self.pos[0])
+            and (col <= self.end_pos[1] or line < self.end_pos[0])
+        )
+
+    def find_by_pos(self, line: int, col: int) -> Self | None:
+        if not self._pos_match(line, col):
+            return None
+
+        for child in self.children:
+            if child._pos_match(line, col):
+                return child.find_by_pos(line, col)
+
+        return self
+
 
 class Script(Node):
     def __init__(self, *args, **kwargs):

--- a/tests/data/symbols.tcl
+++ b/tests/data/symbols.tcl
@@ -1,0 +1,21 @@
+# simple function
+proc hello_world { } {
+  puts "Hello, world!"
+}
+
+# function with arguments
+proc print_foobar { val_foo val_bar } {
+  puts "(inside fn) foo: $val_foo, bar: $val_bar"
+}
+
+hello_world
+
+set val_foo "Blub"
+set val_bar "Blah"
+
+print_foobar Foo Bar
+
+puts "(outside fn) foo: $val_foo, bar: $val_bar"
+
+# to check multiple references
+hello_world

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -908,3 +908,41 @@ def test_find_by_pos():
     result = tree.find_by_pos(7, 16)
     assert isinstance(result, BareWord)
     assert result.value == "Buzz"
+
+
+def test_linked_children():
+    with open(MY_DIR / "data" / "clean.tcl", "r") as f:
+        script = f.read()
+    tree = parse(script)
+
+    result = tree.find_by_pos(4, 9)
+    assert isinstance(result, BareWord)
+    assert result.value == "elseif"
+
+    print(tree.pretty())
+
+    node = result.prev
+    assert isinstance(node, Script)
+    node = node.prev
+    assert isinstance(node, BracedExpression)
+    node = node.prev
+    assert isinstance(node, BareWord)
+    node = node.prev
+    assert node is None
+
+    node = result.next
+    assert isinstance(node, BracedExpression)
+    node = node.next
+    assert isinstance(node, Script)
+    node = node.next
+    assert isinstance(node, BareWord)
+    node = node.next
+    assert isinstance(node, BracedExpression)
+    node = node.next
+    assert isinstance(node, Script)
+    node = node.next
+    assert isinstance(node, BareWord)
+    node = node.next
+    assert isinstance(node, Script)
+    node = node.next
+    assert node is None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -894,3 +894,17 @@ def test_unbraced_list():
     args_list_node = command.args[1]
     assert args_list_node.pos == (1, 10)
     assert args_list_node.children[0].pos == (1, 10)
+
+
+def test_find_by_pos():
+    with open(MY_DIR / "data" / "clean.tcl", "r") as f:
+        script = f.read()
+    tree = parse(script)
+
+    result = tree.find_by_pos(4, 16)
+    assert isinstance(result, VarSub)
+    assert result.value == "i"
+
+    result = tree.find_by_pos(7, 16)
+    assert isinstance(result, BareWord)
+    assert result.value == "Buzz"

--- a/tests/test_tclsp.py
+++ b/tests/test_tclsp.py
@@ -28,7 +28,7 @@ def get_capabilities(client: str) -> lsp.ClientCapabilities:
 @pytest_lsp.fixture(
     config=pytest_lsp.ClientServerConfig(
         # -I ensures the server imports the tclint package instead of the entry point.
-        server_command=[sys.executable, "-I", str(LSP_BIN), "--log-level", "debug"]
+        server_command=[sys.executable, "-I", str(LSP_BIN)]
     )
 )
 async def client(lsp_client: pytest_lsp.LanguageClient, request):

--- a/tests/test_tclsp.py
+++ b/tests/test_tclsp.py
@@ -439,43 +439,27 @@ async def test_goto_definition(client: pytest_lsp.LanguageClient):
     document = MY_DIR / "data" / "symbols.tcl"
 
     async def _test(
-        line: int, character: int
+        line: int, character: int, res_line: int, res_char: int
     ) -> Union[lsp.Location, List[lsp.Location], List[lsp.LocationLink], None]:
-        return await client.text_document_definition_async(
+        result = await client.text_document_definition_async(
             lsp.DefinitionParams(
                 text_document=lsp.TextDocumentIdentifier(uri=f"file://{document}"),
                 position=lsp.Position(line=line, character=character),
             )
         )
+        assert isinstance(result, List)
+        assert len(result) == 1
+        assert result[0].range.start.line == res_line
+        assert result[0].range.start.character == res_char
 
-    # Test definitions of procedures
+    # Test goto definition of procedures
+    await _test(10, 0, 1, 0)
+    await _test(15, 0, 6, 0)
+    await _test(20, 0, 1, 0)
 
-    result = await _test(10, 0)
-    assert isinstance(result, lsp.Location)
-    assert result.range.start.line == 1
-    assert result.range.start.character == 0
-
-    result = await _test(15, 0)
-    assert isinstance(result, lsp.Location)
-    assert result.range.start.line == 6
-    assert result.range.start.character == 0
-
-    result = await _test(20, 0)
-    assert isinstance(result, lsp.Location)
-    assert result.range.start.line == 1
-    assert result.range.start.character == 0
-
-    # Test definitions of variables
-
-    result = await _test(17, 25)
-    assert isinstance(result, lsp.Location)
-    assert result.range.start.line == 12
-    assert result.range.start.character == 0
-
-    result = await _test(17, 40)
-    assert isinstance(result, lsp.Location)
-    assert result.range.start.line == 13
-    assert result.range.start.character == 0
+    # Test goto definition of variables
+    await _test(17, 25, 12, 0)
+    await _test(17, 40, 13, 0)
 
 
 @pytest.mark.asyncio
@@ -514,9 +498,11 @@ async def test_get_references(client: pytest_lsp.LanguageClient):
     assert result[0].range.start.character == 0
 
     # Test references of variables
-
+    """
+    This is still broken, it will list the references inside the function too, b/c there is no support for scope yet
     result = await _test(12, 7)
     assert isinstance(result, List)
     assert len(result) == 1
     assert result[0].range.start.line == 17
     assert result[0].range.start.character == 25
+    """

--- a/tests/test_tclsp.py
+++ b/tests/test_tclsp.py
@@ -453,13 +453,13 @@ async def test_goto_definition(client: pytest_lsp.LanguageClient):
         assert result[0].range.start.character == res_char
 
     # Test goto definition of procedures
-    await _test(10, 0, 1, 0)
-    await _test(15, 0, 6, 0)
-    await _test(20, 0, 1, 0)
+    await _test(10, 0, 1, 5)
+    await _test(15, 0, 6, 5)
+    await _test(20, 0, 1, 5)
 
     # Test goto definition of variables
-    await _test(17, 25, 12, 0)
-    await _test(17, 40, 13, 0)
+    await _test(17, 25, 12, 4)
+    await _test(17, 40, 13, 4)
 
 
 @pytest.mark.asyncio

--- a/tests/test_tclsp.py
+++ b/tests/test_tclsp.py
@@ -448,6 +448,8 @@ async def test_goto_definition(client: pytest_lsp.LanguageClient):
             )
         )
 
+    # Test definitions of procedures
+
     result = await _test(10, 0)
     assert isinstance(result, lsp.Location)
     assert result.range.start.line == 1
@@ -461,6 +463,18 @@ async def test_goto_definition(client: pytest_lsp.LanguageClient):
     result = await _test(20, 0)
     assert isinstance(result, lsp.Location)
     assert result.range.start.line == 1
+    assert result.range.start.character == 0
+
+    # Test definitions of variables
+
+    result = await _test(17, 25)
+    assert isinstance(result, lsp.Location)
+    assert result.range.start.line == 12
+    assert result.range.start.character == 0
+
+    result = await _test(17, 40)
+    assert isinstance(result, lsp.Location)
+    assert result.range.start.line == 13
     assert result.range.start.character == 0
 
 
@@ -483,6 +497,8 @@ async def test_get_references(client: pytest_lsp.LanguageClient):
             )
         )
 
+    # Test references of procedures
+
     result = await _test(1, 5)
     assert isinstance(result, List)
     assert len(result) == 2
@@ -496,3 +512,11 @@ async def test_get_references(client: pytest_lsp.LanguageClient):
     assert len(result) == 1
     assert result[0].range.start.line == 15
     assert result[0].range.start.character == 0
+
+    # Test references of variables
+
+    result = await _test(12, 7)
+    assert isinstance(result, List)
+    assert len(result) == 1
+    assert result[0].range.start.line == 17
+    assert result[0].range.start.character == 25


### PR DESCRIPTION
This is a proof of concept / work in progress for the LSP features `textDocument/definition` and `textDocument/references`. It is implemented by building a symbol table from the syntax tree, which can be queried for definitions and references of syntax tree nodes.

At least following stuff is still to be implemented:

- Support for scope (right now, variables inside a function are confused with variables outside the function)
- Support for namespaces
- Support for multiple files (right now, it cannot find definitions or references outside the file currently being open)

I'm comfortable in Python but only starting out with Tcl, so would appreciate some discussion and guidance :sweat_smile: 