### PR TITLE
ci: add .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: tclint
+    name: tclint
+    description: '`tclint` is a linter for Tcl.'
+    entry: tclint
+    language: python


### PR DESCRIPTION
This allows pre-commit [1] users to add a tclint pre-commit hook in configuration file .pre-commit-config.yaml with:
```
repos:
  - repo: https://github.com/nmoroze/tclint 
    hooks:
    - id: tclint
```

Fixes this issue ( https://github.com/nmoroze/tclint/issues/110 ).

[1] https://pre-commit.com