### PR TITLE
checks: fix handling of command with no switches

### DIFF
--- a/src/tclint/commands/checks.py
+++ b/src/tclint/commands/checks.py
@@ -158,6 +158,10 @@ def check_arg_spec(
     positional_args = []
 
     args = list(args)
+    if not switches:
+        positional_args = args
+        args = []
+
     while len(args) > 0:
         arg = args.pop(0)
 

--- a/tests/commands/test_check_arg_spec.py
+++ b/tests/commands/test_check_arg_spec.py
@@ -168,3 +168,28 @@ def test_arg_replacement_subcommands():
     }
     new_args = check_arg_spec("command", args, None, spec)
     assert new_args == [BareWord("subcommand"), BareWord("arg")]
+
+
+def test_no_switches():
+    # Tcl command: append l -1
+    args = [BareWord("l"), BareWord("-1")]
+    spec = {
+        "positionals": [
+            {"name": "varname", "value": {"type": "any"}, "required": True},
+            {"name": "value", "value": {"type": "variadic"}, "required": False},
+        ],
+        "switches": {},
+    }
+    check_arg_spec("command", args, None, spec)
+
+    # Tcl command: puts -nonewline stdout foo
+    args = [BareWord("-nonewline"), BareWord("stdout"), BareWord("foo")]
+    spec = {
+        "positionals": [
+            {"name": "-nonewline", "value": {"type": "any"}, "required": False},
+            {"name": "channelId", "value": {"type": "any"}, "required": False},
+            {"name": "string", "value": {"type": "any"}, "required": True},
+        ],
+        "switches": {},
+    }
+    check_arg_spec("command", args, None, spec)


### PR DESCRIPTION
With the following tcl code:
```
append l -1
```
we get with tclint:
```
unrecognized argument for append: -1 [command-args]
```

Likewise for "-nonewline" in:
```
puts -nonewline stdout foo
```

Fix this in check_arg_spec by deciding that for a command with no switches, all arguments are positional.

Fixes issues:
- https://github.com/nmoroze/tclint/issues/106
- https://github.com/nmoroze/tclint/issues/108

This also means that "-nonewlin" is no longer reported as unrecognized argument in:
```
puts -nonewlin stdout foo
```