### PR TITLE
project: require pip >= 25.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Use the following steps to set up `tclint` for local development:
 ```sh
 $ git clone https://github.com/nmoroze/tclint.git # or URL to fork
 $ cd tclint
+$ pip install -e .              # Update pip to handle --group.
 $ pip install -e . --group dev
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "importlib-metadata==6.8.0",
     "pygls==1.3.1",
     "voluptuous==0.15.2",
+    "pip>=25.1"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
README.md proposes to use:
```
$ pip install -e . --group dev
```
but --group is only supported starting pip version 25.1.

Fix this by:
- requiring pip >= 25.1
- updating README.md to first do `pip install -e .`

Fixes issue:
- https://github.com/nmoroze/tclint/issues/113