### PR TITLE
ci: add .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: local
+    hooks:
+    - id: black
+      name: black
+      language: python
+      entry: black
+      files: '^.*\.py$'
+      args: [--preview]
+  - repo: local
+    hooks:
+    - id: flake8
+      name: flake8
+      language: python
+      entry: flake8
+      files: '^.*\.py$'
+  - repo: local
+    hooks:
+    - id: mypy
+      name: mypy
+      language: python
+      entry: mypy
+      files: '^src/.*\.py$'
+  - repo: local
+    hooks:
+    - id: codespell
+      name: codespell
+      language: python
+      entry: codespell
+      files: '^.*$'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
 dev = [
   {include-group = "format"},
   {include-group = "lint"},
-  {include-group = "test"}
+  {include-group = "test"},
+  "pre-commit==3.2.0",
 ]
 format = [
     "black==23.11.0",

--- a/util/pre-commit
+++ b/util/pre-commit
@@ -2,8 +2,8 @@
 
 set -e
 
-black --check --preview .
-flake8 .
+pre-commit run --all-files black
+pre-commit run --all-files flake8
 pytest
-mypy src/
-git ls-files | xargs codespell
+pre-commit run --all-files mypy
+pre-commit run --all-files codespell


### PR DESCRIPTION
We have a pre-commit script util/pre-commit calling various checkers as well as pytest, but it's still up to the developer to call it.

Using the pre-commit framework [1], we can make sure that the checkers are called every commit.

Add a file .pre-commit-config.yaml containing hooks for:
- black
- flake8
- mypy
- codespell

I could also have added pytest, but it seems excessive to do this for every commit.

I've added pre-commit to the dev group of dependencies, which means the git pre-commit checks will get activated for each developer that runs the setup command.

It's possible to not do this, but then the changes to util/pre-commit will have to be reverted.

Fixes issue:
- https://github.com/nmoroze/tclint/issues/112

[1] https://pre-commit.com/