### PR TITLE
ci: configure black in pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ pip install -e . --group dev
 Please format, lint, and run tests before submitting changes:
 
 ```sh
-$ black --preview .
+$ black .
 $ ./util/pre-commit
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,6 @@ module = [
     "ply.*",
 ]
 ignore_missing_imports = true
+
+[tool.black]
+preview = true

--- a/util/pre-commit
+++ b/util/pre-commit
@@ -2,7 +2,7 @@
 
 set -e
 
-black --check --preview .
+black --check .
 flake8 .
 pytest
 mypy src/


### PR DESCRIPTION
Currently developers are required to run:
```
$ black --preview .
```

Add a tool.black section in pyproject.toml, setting preview to true, such that we can do simply:
```
$ black .
```

I've left the --preview in place in ./.github/workflows/ci.yml, I'm not able to test whether it can be removed.