### PR TITLE
project: require pytest 8.2.0, fix pytest warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,10 @@ lint = [
     "codespell==2.3.0",
 ]
 test = [
-    "pytest==7.4.0",
+    "pytest==8.2.0",
     "pytest-timeout==2.2.0",
     "pytest-lsp==0.4.3",
+    "pytest-asyncio==0.24",
 ]
 
 [project.scripts]


### PR DESCRIPTION
With python 3.9, I run into this warning with pytest:
```
$ pytest
  ...
=================================== warnings summary ====================================
../lib64/python3.9/site-packages/_pytest/config/__init__.py:1373
  /home/vries/python-3.9-venv/lib64/python3.9/site-packages/_pytest/config/__init__.py:1373: PytestConfigWarning: Unknown config option: asyncio_default_fixture_loop_scope

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 172 passed, 4 skipped, 1 warning in 3.78s =======================
$
```

The problem is that in pyproject.toml we specify:
```
[tool.pytest.ini_options]
  ...
asyncio_default_fixture_loop_scope = "function"
```
but asyncio_default_fixture_loop_scope is only available starting pytest-asyncio v0.24, and the installed version is:
```
$ pip show pytest-asyncio
Name: pytest-asyncio
Version: 0.23.8
```

Fix this by requiring pytest-asyncio v0.24.  That requires us to upgrade pytest to v8.2.0.