### PR TITLE
format: add tclfmt --indent=mixed,<s>,<t>

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ commands = "~/.tclint/openroad.json"
 # with the exception of line-length, the [style] settings affect tclfmt rather than tclint.
 
 [style]
-# number of spaces to indent. can also be set to "tab". defaults to 4.
+# number of spaces to indent. can also be set to "tab", or "mixed",<s>,<t>. defaults to 4.
 indent = 2
 # maximum allowed line length. defaults to 100.
 line-length = 80

--- a/src/tclint/cli/tclfmt.py
+++ b/src/tclint/cli/tclfmt.py
@@ -34,6 +34,7 @@ def format(script: str, config: Config, debug=False) -> str:
     formatter = Formatter(
         FormatterOpts(
             indent=config.get_indent(),
+            indent_mixed_tab_size=config.get_indent_mixed_tab_size(),
             spaces_in_braces=config.style_spaces_in_braces,
             max_blank_lines=config.style_max_blank_lines,
             indent_namespace_eval=config.style_indent_namespace_eval,

--- a/src/tclint/cli/tclsp.py
+++ b/src/tclint/cli/tclsp.py
@@ -205,6 +205,7 @@ class TclspServer(LanguageServer):
         formatter = Formatter(
             FormatterOpts(
                 indent=indent,
+                indent_mixed_tab_size=0,
                 spaces_in_braces=config.style_spaces_in_braces,
                 max_blank_lines=config.style_max_blank_lines,
                 indent_namespace_eval=config.style_indent_namespace_eval,


### PR DESCRIPTION
Allow for a style of indentation that mixes spaces and tabs, say indentation of 4 spaces, and tab size 8:
```
foo
<sp>foo
<TAB   >foo
<TAB   ><sp>foo
<TAB   ><TAB   >foo
```

To specify this style of indentation, use --indent=mixed,4,8.

Fixes https://github.com/nmoroze/tclint/issues/109.