### PR TITLE
tclfmt: add --partial to handle script fragment

### DIFF
--- a/docs/tclfmt.md
+++ b/docs/tclfmt.md
@@ -156,6 +156,31 @@ set foo [
 ]
 ```
 
+### Complete script vs. script fragment
+
+By default, `tclfmt` formats its input assuming it's a complete script.
+
+The LSP server `tclsp` formats fragments of scripts instead.
+
+If we pass `--partial` to `tclfmt`, it also formats its input assuming it's a
+script fragment.
+
+To demonstrate the difference, this input:
+```tcl
+    if 1 {}
+        if 1 {}
+```
+is transformed into this format with `--partial`:
+```tcl
+    if 1 {}
+    if 1 {}
+```
+but into this format with the default `--no-partial`:
+```tcl
+if 1 {}
+if 1 {}
+```
+
 ### Line length
 
 `tclfmt` does not (yet) reformat lines to stay under a certain length. However, it

--- a/src/tclint/cli/tclfmt.py
+++ b/src/tclint/cli/tclfmt.py
@@ -39,7 +39,10 @@ def format(script: str, config: Config, debug=False) -> str:
             indent_namespace_eval=config.style_indent_namespace_eval,
         )
     )
-    return formatter.format_top(script, parser)
+    if config.style_partial:
+        return formatter.format_partial(script, parser)
+    else:
+        return formatter.format_top(script, parser)
 
 
 def check(path: pathlib.Path, script: str, formatted: str):

--- a/src/tclint/config.py
+++ b/src/tclint/config.py
@@ -35,6 +35,7 @@ class Config:
     style_max_blank_lines: int = dataclasses.field(default=2)
     style_indent_namespace_eval: bool = dataclasses.field(default=True)
     style_spaces_in_braces: bool = dataclasses.field(default=False)
+    style_partial: bool = dataclasses.field(default=False)
 
     def apply_cli_args(self, args):
         args_dict = vars(args)
@@ -112,6 +113,7 @@ _VALIDATORS = {
     ),
     "style_indent_namespace_eval": bool,
     "style_spaces_in_braces": bool,
+    "style_partial": bool,
 }
 
 
@@ -131,6 +133,7 @@ def _validate_config(config):
                 "style_indent_namespace_eval"
             ],
             Optional("spaces-in-braces"): _VALIDATORS["style_spaces_in_braces"],
+            Optional("partial"): _VALIDATORS["style_partial"],
         },
     }
 
@@ -252,6 +255,13 @@ def setup_tclfmt_config_cli_args(parser):
         "style_spaces_in_braces",
         "--spaces-in-braces",
         "--no-spaces-in-braces",
+    )
+    _add_bool(
+        config_group,
+        parser,
+        "style_partial",
+        "--partial",
+        "--no-partial",
     )
 
 


### PR DESCRIPTION
By default, `tclfmt` handles its input as a complete script:
```
$ echo -e "    if 1 {}\n        if 1 {}" | tclfmt -
if 1 {}
if 1 {}
```

Add an option --partial that makes `tclfmt` handle its input as a script fragment, like `tclsp`:
```
$ echo -e "    if 1 {}\n        if 1 {}" | tclfmt --partial -
    if 1 {}
    if 1 {}
```

This makes it possible to play around with the formatting capability of `tclsp` without having to setup an LSP client.

Fixes:
- https://github.com/nmoroze/tclint/issues/127