### PR TITLE
ci: add tclfmt in .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,3 +3,8 @@
     description: '`tclint` is a linter for Tcl.'
     entry: tclint
     language: python
+-   id: tclfmt
+    name: tclfmt
+    description: '`tclfmt` is a formatter for Tcl.'
+    entry: tclfmt
+    language: python


### PR DESCRIPTION
This allows pre-commit users to add a tclfmt pre-commit hook in configuration file .pre-commit-config.yaml with:
```
repos:
- repo: https://github.com/nmoroze/tclint
    hooks:
    - id: tclfmt
      args: [--in-place]
```
or with `--check` instead.

Fixes issue:
- https://github.com/nmoroze/tclint/issues/133