### PR TITLE
plugins: support tclint --commands dynamic-plugin.py

### DIFF
--- a/src/tclint/commands/__init__.py
+++ b/src/tclint/commands/__init__.py
@@ -28,7 +28,10 @@ def get_commands(plugins: Sequence[Union[str, pathlib.Path]]) -> Dict:
         if isinstance(plugin, str):
             plugin_commands = PluginManager.load(plugin)
         elif isinstance(plugin, pathlib.Path):
-            plugin_commands = PluginManager.load_from_spec(plugin)
+            if plugin.suffix == ".py":
+                plugin_commands = PluginManager.load_from_py(plugin)
+            else:
+                plugin_commands = PluginManager.load_from_spec(plugin)
         else:
             raise TypeError(f"Plugins must be strings or paths, got {type(plugin)}")
 

--- a/tests/commands/data/dynamic.py
+++ b/tests/commands/data/dynamic.py
@@ -1,0 +1,13 @@
+from tclint.commands.checks import (
+    CommandArgError,
+)
+from tclint.commands.schema import commands_schema
+
+
+def _foo(args, parser):
+    raise CommandArgError("foo")
+
+
+commands = commands_schema({
+    "foo": _foo,
+})

--- a/tests/commands/test_plugin.py
+++ b/tests/commands/test_plugin.py
@@ -18,3 +18,9 @@ def test_load_invalid():
     plugins = PluginManager()
     loaded = plugins.load_from_spec(TEST_DATA_DIR / "invalid.json")
     assert loaded is None
+
+
+def test_load_py():
+    plugins = PluginManager()
+    loaded = plugins.load_from_py(TEST_DATA_DIR / "dynamic.py")
+    assert isinstance(loaded, dict)


### PR DESCRIPTION
Tclint supports plugins, both static and dynamic ones.

A static plugin can be specified using a JSON file:
```
$ tclint --commands foo.json ...
```

A dynamic plugin can be specified using a plugin discovery mechanism called entry points, which requires wrapping the plugin in a python package and advertising the plugin in the package metadata.

Add a simpler way of specifying a dynamic plugin: specifying the python file containing it:
```
$ tclint --commands foo.py ...
```

Fixes issue:
- https://github.com/nmoroze/tclint/issues/121