### PR TITLE
format: emacs tcl mode indentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,6 +31,8 @@ indent-namespace-eval = false
 # whether to expect a single space (true) or no spaces (false) surrounding the contents of a braced expression or script argument.
 # defaults to false.
 spaces-in-braces = true
+# (experimental) make formatting similar to emacs tcl mode.
+emacs = false
 ```
 
 ## Config discovery

--- a/docs/tclfmt.md
+++ b/docs/tclfmt.md
@@ -161,6 +161,12 @@ set foo [
 ]
 ```
 
+### Emacs Indentation
+
+An experimental mode (`--emacs`) is available to make indentation style similar
+to emacs tcl mode.  The goal is to minimize changes in code written in this
+editing mode.
+
 ### Line length
 
 `tclfmt` does not (yet) reformat lines to stay under a certain length. However, it

--- a/src/tclint/cli/tclfmt.py
+++ b/src/tclint/cli/tclfmt.py
@@ -36,6 +36,7 @@ def format(
             spaces_in_braces=config.style_spaces_in_braces,
             max_blank_lines=config.style_max_blank_lines,
             indent_namespace_eval=config.style_indent_namespace_eval,
+            emacs=config.style_emacs,
         )
     )
     if partial:

--- a/src/tclint/cli/tclsp.py
+++ b/src/tclint/cli/tclsp.py
@@ -260,6 +260,7 @@ class TclspServer(LanguageServer):
                 spaces_in_braces=config.style_spaces_in_braces,
                 max_blank_lines=config.style_max_blank_lines,
                 indent_namespace_eval=config.style_indent_namespace_eval,
+                emacs=False,
             )
         )
 

--- a/src/tclint/config.py
+++ b/src/tclint/config.py
@@ -43,6 +43,7 @@ class Config:
     style_max_blank_lines: int = dataclasses.field(default=2)
     style_indent_namespace_eval: bool = dataclasses.field(default=True)
     style_spaces_in_braces: bool = dataclasses.field(default=False)
+    style_emacs: bool = dataclasses.field(default=False)
 
     def apply_cli_args(self, args):
         args_dict = vars(args)
@@ -222,6 +223,7 @@ _validate_style_max_blank_lines = And(
 )
 _validate_style_indent_namespace_eval = bool
 _validate_style_spaces_in_braces = bool
+_validate_style_emacs = bool
 
 
 def _error_if_dynamic_plugin(p: pathlib.Path):
@@ -386,6 +388,13 @@ def setup_tclfmt_config_cli_args(parser, cwd: pathlib.Path):
         "style_spaces_in_braces",
         "--spaces-in-braces",
         "--no-spaces-in-braces",
+    )
+    _add_bool(
+        config_group,
+        parser,
+        "style_emacs",
+        "--emacs",
+        "--no-emacs",
     )
 
 

--- a/src/tclint/format.py
+++ b/src/tclint/format.py
@@ -40,6 +40,7 @@ class FormatterOpts:
     max_blank_lines: int
     indent_namespace_eval: bool
     indent_mixed_tab_size: int
+    emacs: bool
 
 
 class Formatter:
@@ -291,6 +292,10 @@ class Formatter:
 
             if last_line == child.pos[0]:
                 formatted[-1] += " "
+                if self.opts.emacs and child_lines[0][-1] == "\\":
+                    base_indent = (len(formatted[-1])) * " "
+                else:
+                    base_indent = ""
                 formatted[-1] += child_lines[0]
             else:
                 formatted[-1] += " \\"
@@ -300,7 +305,7 @@ class Formatter:
             if hanging_indent:
                 formatted.extend(self._indent(child_lines[1:], self.opts.indent))
             else:
-                formatted.extend(child_lines[1:])
+                formatted.extend(self._indent(child_lines[1:], base_indent))
 
             last_line = child.end_pos[0]
 
@@ -321,7 +326,11 @@ class Formatter:
             formatted.append("]")
         else:
             formatted.append("[" + contents[0])
-            formatted.extend(contents[1:])
+            if self.opts.emacs:
+                indent = " "
+            else:
+                indent = ""
+            formatted.extend(self._indent(contents[1:], indent))
             formatted[-1] += "]"
 
         return formatted

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -14,6 +14,7 @@ def _test(
     spaces_in_braces=True,
     max_blank_lines=2,
     indent_namespace_eval=True,
+    emacs=False,
 ):
     parser = Parser()
     format = Formatter(
@@ -23,6 +24,7 @@ def _test(
             spaces_in_braces=spaces_in_braces,
             max_blank_lines=max_blank_lines,
             indent_namespace_eval=indent_namespace_eval,
+            emacs=emacs,
         )
     )
     out = format.format_top(script, parser)
@@ -677,6 +679,7 @@ def test_partial():
             spaces_in_braces=True,
             max_blank_lines=2,
             indent_namespace_eval=True,
+            emacs=False,
         )
     )
 
@@ -714,6 +717,7 @@ puts "three"
             spaces_in_braces=True,
             max_blank_lines=2,
             indent_namespace_eval=True,
+            emacs=False,
         )
     )
 
@@ -745,6 +749,7 @@ def test_partial_mixed():
             spaces_in_braces=True,
             max_blank_lines=2,
             indent_namespace_eval=True,
+            emacs=False,
         )
     )
 
@@ -780,6 +785,7 @@ puts "foo"
             spaces_in_braces=True,
             max_blank_lines=2,
             indent_namespace_eval=True,
+            emacs=False,
         )
     )
 
@@ -805,3 +811,18 @@ switch a {
 }
 """.strip()
     _test(script, script, spaces_in_braces=True)
+
+
+def test_hanging_indent():
+    script = r"""
+set options [list a \
+                 b c \
+                 d \
+                 e]
+set options \
+    [list a \
+         b c \
+         d \
+         e]
+""".strip()
+    _test(script, script, indent="    ", emacs=True)


### PR DESCRIPTION
The emacs tcl mode auto-indents like this:
```
set options [list a \
                 b c \
                 d \
                 e]
```

Tclfmt formats this code like this instead:
```
set options [list a \
    b c \
    d \
    e]
```
Add an option `--emacs` that uses the emacs tcl mode style instead.

The option is incomplete, which is why it's marked as experimental.

Fixes issue:
- https://github.com/nmoroze/tclint/issues/139