### PR TITLE
lsp: add missing SymbolTable.__init__ type annotation

### DIFF
--- a/src/tclint/symbol_table.py
+++ b/src/tclint/symbol_table.py
@@ -7,7 +7,7 @@ from tclint.syntax_tree import Command, CommandSub, Node, Script, Visitor
 class SymbolTable:
     """Holds a symbol table (links symbols to nodes)."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.proc_def: defaultdict[str, list[Node]] = defaultdict(list)
 
     def add_proc_definition(self, command: Command) -> None:


### PR DESCRIPTION
When running mypy, I get:
```
src/tclint/symbol_table.py:11: note: By default the bodies of untyped \
  functions are not checked, consider using --check-untyped-defs
  \ [annotation-unchecked]
```

Fix this by adding "-> None" type annotation to `<SymbolTable.__init__`.