### PR TITLE
commands: add missing type annotation

### DIFF
--- a/src/tclint/commands/builtin.py
+++ b/src/tclint/commands/builtin.py
@@ -429,7 +429,7 @@ def foreach(args, parser):
     return check_arg_spec("foreach", args, parser, spec)
 
 
-def _if(args, parser):
+def _if(args, parser) -> list[Node]:
     # ref: https://www.tcl-lang.org/man/tcl8.6/TclCmd/if.htm
 
     new_args: list[Node] = []

--- a/src/tclint/commands/plugins.py
+++ b/src/tclint/commands/plugins.py
@@ -13,7 +13,7 @@ from tclint.commands import schema
 
 
 class PluginManager:
-    def __init__(self, trust_uninstalled=False):
+    def __init__(self, trust_uninstalled=False) -> None:
         self._loaded: dict[str, Optional[dict]] = {}
         self._installed: dict[str, EntryPoint] = {}
         self._loaded_specs: dict[pathlib.Path, Optional[dict]] = {}


### PR DESCRIPTION
Fix the following notes:
```
src/tclint/commands/builtin.py:435: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/tclint/commands/plugins.py:17: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/tclint/commands/plugins.py:18: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/tclint/commands/plugins.py:19: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/tclint/commands/plugins.py:20: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
```
by adding missing type annotation.