### PR TITLE
util: make pre-commit a bit more verbose

### DIFF
--- a/util/pre-commit
+++ b/util/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 black --check .
 flake8 .


### PR DESCRIPTION
I ran `util/pre-commit`, and saw at the end of the output:
```
Success: no issues found in 22 source files
Skipped 2 files
```

I wondered why `mypy` skipped 2 files, but after investigating this I realized that the "Skipped 2 files" message is from isort.

Fix this by logging when we start a new tool:
```
=== mypy ===
Success: no issues found in 22 source files
=== codespell ===
=== isort ===
Skipped 2 files
$
```