### PR TITLE
config: add emacs config option in config file

### DIFF
--- a/src/tclint/config.py
+++ b/src/tclint/config.py
@@ -278,6 +278,7 @@ def _validate_config(config: dict, root: pathlib.Path):
             Optional("max-blank-lines"): _validate_style_max_blank_lines,
             Optional("indent-namespace-eval"): _validate_style_indent_namespace_eval,
             Optional("spaces-in-braces"): _validate_style_spaces_in_braces,
+            Optional("emacs"): _validate_style_emacs,
         },
     })
 

--- a/tests/data/tclint.toml
+++ b/tests/data/tclint.toml
@@ -20,3 +20,5 @@ indent-namespace-eval = false
 # whether to expect a single space (true) or no spaces (false) surrounding the contents of a braced expression or script argument.
 # defaults to false.
 spaces-in-braces = true
+# whether to use the emacs formatting style.  defaults to false.
+emacs = true

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,7 @@ def test_example_config():
     assert config.style_line_length == 80
     assert config.style_indent_namespace_eval is False
     assert config.style_spaces_in_braces == SpacesInBraces.ALWAYS
+    assert config.style_emacs is True
 
 
 def test_invalid_rule():


### PR DESCRIPTION
A recent commit adds the experimental `--emacs` CLI option, but there's no corresponding config file option.  Add this.