### PR TITLE
format: add debug mode to track down spaces

### DIFF
--- a/src/tclint/cli/tclsp.py
+++ b/src/tclint/cli/tclsp.py
@@ -274,6 +274,7 @@ class TclspServer(LanguageServer):
                 max_blank_lines=config.style_max_blank_lines,
                 indent_namespace_eval=config.style_indent_namespace_eval,
                 emacs=False,
+                debug_whitespace=False,
             )
         )
 

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -16,6 +16,7 @@ def _test(
     max_blank_lines=2,
     indent_namespace_eval=True,
     emacs=False,
+    debug_whitespace=False,
 ):
     parser = Parser()
     format = Formatter(
@@ -27,6 +28,7 @@ def _test(
             max_blank_lines=max_blank_lines,
             indent_namespace_eval=indent_namespace_eval,
             emacs=emacs,
+            debug_whitespace=debug_whitespace,
         )
     )
     out = format.format_top(script, parser)
@@ -731,6 +733,7 @@ def test_partial():
             max_blank_lines=2,
             indent_namespace_eval=True,
             emacs=False,
+            debug_whitespace=False,
         )
     )
 
@@ -770,6 +773,7 @@ puts "three"
             max_blank_lines=2,
             indent_namespace_eval=True,
             emacs=False,
+            debug_whitespace=False,
         )
     )
 
@@ -803,6 +807,7 @@ def test_partial_mixed():
             max_blank_lines=2,
             indent_namespace_eval=True,
             emacs=False,
+            debug_whitespace=False,
         )
     )
 
@@ -840,6 +845,7 @@ puts "foo"
             max_blank_lines=2,
             indent_namespace_eval=True,
             emacs=False,
+            debug_whitespace=False,
         )
     )
 


### PR DESCRIPTION
While investigating formatting, I'm regularly confronted with the question: where does that (indentation) space come from?

Say we format input:
```
if {1} {
    [foo \
         a \
         b]
}
```
as:
```
if { 1 } {
    [foo \
        a \
        b]
}
```

Add a mode that replaces spaces with capitals:
```
ifF{A1A}F{
EEEE[foo \
EEEEHHHHa \
EEEEHHHHb]
}
```
where each capital indicates at which line in format.py it was generated.

The mode is hard-coded to disabled using an "if False".  It's possible to to enable this using -d/--debug instead.