### PR TITLE
commands: fix eval position with braced arg

### DIFF
--- a/src/tclint/commands/checks.py
+++ b/src/tclint/commands/checks.py
@@ -124,7 +124,7 @@ def eval(args: list[Node], parser: Parser, command: str) -> list[Node]:
 
         prev_arg_end_pos = arg.end_pos
 
-    script = parser.parse(eval_script, pos=(args[0].pos))
+    script = parser.parse(eval_script, pos=(args[0].contents_pos))
     script.end_pos = args[-1].end_pos
 
     return [script]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -484,6 +484,22 @@ def test_eval_positions():
     assert command.children[2].pos == (2, 2)
 
 
+def test_eval_braced_positions():
+    script = "eval { {*}[lindex $args 0] }"
+
+    tree = parse(script)
+    eval_command = tree.children[0]
+    inner_script = eval_command.args[0]
+    command = inner_script.children[0]
+    assert command.pos == (1, 8)
+    arg_expansion = command.children[0]
+    assert arg_expansion.pos == (1, 8)
+    command_sub = arg_expansion.children[0]
+    assert command_sub.pos == (1, 11)
+    lindex = command_sub.children[0].children[0]
+    assert lindex.pos == (1, 12)
+
+
 def test_eval_braced_multi_arg():
     script = "eval puts {a b c}"
 


### PR DESCRIPTION
When eval receives a braced argument, parsing was starting at the position of the opening brace rather than the first character inside the brace, causing all positions to be off by one column.

Fixes #151

Generated with [Claude Code](https://claude.ai/code)