### PR TITLE
Improve command argument diagnostics and suggestions

### DIFF
--- a/src/tclint/commands/builtin.py
+++ b/src/tclint/commands/builtin.py
@@ -573,7 +573,16 @@ def _package_ifneeded(args, parser):
 
 
 def _proc(args, parser):
-    if len(args) != 3:
+    required_args = ["name", "args", "body"]
+    if len(args) < len(required_args):
+        missing_args = ", ".join(required_args[len(args) :])
+        raise CommandArgError(
+            "missing required"
+            f" argument{'s' if len(args) < len(required_args) - 1 else ''} for proc:"
+            f" {missing_args}"
+        )
+
+    if len(args) > len(required_args):
         raise CommandArgError(f"wrong # of args to proc: got {len(args)}, expected 3")
 
     # Parse args as list, then iterate over each item to parse arg specifier lists and

--- a/src/tclint/commands/checks.py
+++ b/src/tclint/commands/checks.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from difflib import get_close_matches
 from typing import TYPE_CHECKING, Optional
 
 from tclint.syntax_tree import ArgExpansion, BareWord, BracedWord, Node, QuotedWord
@@ -16,6 +17,33 @@ class CommandArgError(Exception):
     """Exception raised by command handlers to indicate invalid arguments."""
 
     pass
+
+
+def get_suggestion(value: str | None, candidates: Iterable[str]) -> Optional[str]:
+    if value is None:
+        return None
+
+    unique_candidates = sorted({candidate for candidate in candidates if candidate})
+    if value in unique_candidates:
+        unique_candidates.remove(value)
+
+    if not unique_candidates:
+        return None
+
+    cutoff = 0.85 if len(value) <= 3 else 0.75
+    matches = get_close_matches(value, unique_candidates, n=1, cutoff=cutoff)
+    if not matches:
+        return None
+
+    return matches[0]
+
+
+def _did_you_mean_suffix(value: str | None, candidates: Iterable[str]) -> str:
+    suggestion = get_suggestion(value, candidates)
+    if suggestion is None:
+        return ""
+
+    return f"; did you mean {suggestion}?"
 
 
 def arg_count(args: list[Node], parser: Parser) -> tuple[int, bool]:
@@ -213,12 +241,18 @@ def dispatch_subcommands(
     if "" in spec:
         return check_command(command, args, parser, spec[""])
 
+    valid_subcommands = [name for name in spec.keys() if name != ""]
+
     if subcommand is not None:
         msg = f"invalid subcommand for {command}: got {subcommand}"
+        suggestion = _did_you_mean_suffix(subcommand, valid_subcommands)
     else:
         msg = f"no subcommand provided for {command}"
+        suggestion = ""
 
-    raise CommandArgError(f"{msg}, expected one of {', '.join(spec.keys())}")
+    raise CommandArgError(
+        f"{msg}, expected one of {', '.join(valid_subcommands)}{suggestion}"
+    )
 
 
 def map_switches(
@@ -299,7 +333,10 @@ def map_switches(
                 f" {', '.join(prefix_matches)}"
             )
 
-        raise CommandArgError(f"unrecognized argument for {command_name}: {contents}")
+        raise CommandArgError(
+            f"unrecognized argument for {command_name}: {contents}"
+            f"{_did_you_mean_suffix(contents, switches.keys())}"
+        )
 
     return mapped, positional_args
 

--- a/src/tclint/symbol_table.py
+++ b/src/tclint/symbol_table.py
@@ -13,6 +13,9 @@ class SymbolTable:
     def add_proc_definition(self, command: Command) -> None:
         """Add definition of procedure"""
         # command holds the "proc" keyword, so the proc name is 1st argument
+        if len(command.args) == 0:
+            return
+
         proc_name_node = command.args[0]
         proc_name = proc_name_node.contents
         if not proc_name:

--- a/tests/commands/test_check_arg_spec.py
+++ b/tests/commands/test_check_arg_spec.py
@@ -250,11 +250,11 @@ def test_subcommand_suggestion():
     }
 
     with pytest.raises(CommandArgError) as excinfo:
-        check_arg_spec("dict", [BareWord("apend")], None, spec)
+        check_arg_spec("dict", [BareWord("appendd")], None, spec)
 
     assert (
         str(excinfo.value)
-        == "invalid subcommand for dict: got apend, expected one of append, remove;"
+        == "invalid subcommand for dict: got appendd, expected one of append, remove;"
         " did you mean append?"
     )
 

--- a/tests/commands/test_check_arg_spec.py
+++ b/tests/commands/test_check_arg_spec.py
@@ -147,6 +147,27 @@ def test_invalid_int_switch_value():
     assert str(excinfo.value) == "invalid value for command -foo: got abc, expected int"
 
 
+def test_unknown_switch_suggestion():
+    spec = {
+        "positionals": [],
+        "switches": {
+            "-verbose": {
+                "required": False,
+                "value": None,
+                "repeated": False,
+            },
+        },
+    }
+
+    with pytest.raises(CommandArgError) as excinfo:
+        check_arg_spec("command", [BareWord("-verboes")], None, spec)
+
+    assert (
+        str(excinfo.value)
+        == "unrecognized argument for command: -verboes; did you mean -verbose?"
+    )
+
+
 def test_missing_switch_value_hint_uses_metavar():
     spec = {
         "positionals": [],
@@ -218,6 +239,24 @@ def test_subcommands(args, valid):
 
     if excinfo is not None:
         print(excinfo.value)
+
+
+def test_subcommand_suggestion():
+    spec = {
+        "subcommands": {
+            "append": None,
+            "remove": None,
+        }
+    }
+
+    with pytest.raises(CommandArgError) as excinfo:
+        check_arg_spec("dict", [BareWord("apend")], None, spec)
+
+    assert (
+        str(excinfo.value)
+        == "invalid subcommand for dict: got apend, expected one of append, remove;"
+        " did you mean append?"
+    )
 
 
 def test_arg_replacement_subcommands():

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -186,3 +186,14 @@ def test_proc_no_args():
     violations = lint(script, Config(), Path())
     assert len(violations) == 1
     assert violations[0].id == Rule("command-args")
+    assert (
+        violations[0].message == "missing required arguments for proc: name, args, body"
+    )
+
+
+def test_puts_no_args_message():
+    script = "puts"
+    violations = lint(script, Config(), Path())
+    assert len(violations) == 1
+    assert violations[0].id == Rule("command-args")
+    assert violations[0].message == "missing required argument for puts: string"


### PR DESCRIPTION

This PR improves command argument diagnostics by adding spelling suggestions for invalid subcommands and unrecognized switches, and by naming missing positional arguments in error messages.

Examples:
- `invalid subcommand for dict: got apend, expected one of append, remove; did you mean append?`
- `unrecognized argument for command: -verboes; did you mean -verbose?`
- `missing required arguments for proc: name, args, body`

This does not add top-level unknown-command detection. Per the discussion in #104 , I left that out for now to avoid false positives for user-defined commands.

Added tests for subcommand suggestions, switch suggestions, and named missing positional arguments.